### PR TITLE
Updated 0x/mesh-rpc-client package version and get the length of orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "add-orders": "tsc; node lib/add_orders.js"
   },
   "dependencies": {
-    "@0x/mesh-rpc-client": "^3.0.1-beta"
+    "@0x/mesh-rpc-client": "^7.0.1-beta"
   },
   "devDependencies": {
-    "typescript": "^3.5.3"
+    "typescript": "^3.7.4"
   }
 }

--- a/src/all_orders.ts
+++ b/src/all_orders.ts
@@ -5,7 +5,7 @@ import { WSClient } from '@0x/mesh-rpc-client';
 
     const orders = await c.getOrdersAsync();
 
-    console.log(`Got ${orders.length} orders!`);
+    console.log(`Got ${orders.ordersInfos.length} orders!`);
 
     process.exit(0);
 })()


### PR DESCRIPTION
Change in package.json and all_orders.ts

package.json: change version of 0x/mesh-rpc-client
all_orders.ts : change the updated way to get length of all orders
